### PR TITLE
feat: fix subtitle preview rendering and add FunASR helper tools

### DIFF
--- a/core/subtitle_burner.py
+++ b/core/subtitle_burner.py
@@ -214,7 +214,9 @@ class SubtitleBurner:
             )
             family = (result.stdout or "").strip().splitlines()
             if result.returncode == 0 and family and family[0].strip():
-                return family[0].strip()
+                primary_family = family[0].split(",", 1)[0].strip()
+                if primary_family:
+                    return primary_family
         except (FileNotFoundError, OSError):
             pass
 
@@ -660,30 +662,76 @@ class SubtitleBurner:
         tmp_fd, tmp_ass_str = tempfile.mkstemp(suffix=".ass")
         os.close(tmp_fd)
         tmp_ass = Path(tmp_ass_str)
+        tmp_bg_video = tmp_ass.with_suffix(".mp4")
+        tmp_burned_video = tmp_ass.with_name(f"{tmp_ass.stem}_burned.mp4")
         try:
             tmp_ass.write_bytes(ass.read_bytes())
-            cmd = [
+
+            background_cmd = [
                 "ffmpeg",
                 "-loop", "1",
                 "-i", str(background.resolve()),
-                "-vf", self.build_ass_filter_value(tmp_ass.name, language="zh"),
-                "-frames:v", "1",
-                "-y", str(output.resolve()),
+                "-t", "2",
+                "-pix_fmt", "yuv420p",
+                "-an",
+                "-y", str(tmp_bg_video.resolve()),
             ]
-            r = subprocess.run(
-                cmd,
+            background_result = subprocess.run(
+                background_cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            if background_result.returncode != 0:
+                stderr_tail = (background_result.stderr or "")[-500:]
+                logger.error(f"ffmpeg preview background video error: {stderr_tail}")
+                return False
+
+            burn_cmd = [
+                "ffmpeg",
+                "-i", str(tmp_bg_video.resolve()),
+                "-vf", self.build_ass_filter_value(tmp_ass.name, language="zh"),
+                "-pix_fmt", "yuv420p",
+                "-an",
+                "-y", str(tmp_burned_video.resolve()),
+            ]
+            burn_result = subprocess.run(
+                burn_cmd,
                 cwd=str(tmp_ass.parent),
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
                 errors="replace",
             )
-            if r.returncode != 0:
-                stderr_tail = (r.stderr or "")[-500:]
+            if burn_result.returncode != 0:
+                stderr_tail = (burn_result.stderr or "")[-500:]
                 logger.error(f"ffmpeg preview subtitle error: {stderr_tail}")
-            return r.returncode == 0
+                return False
+
+            frame_cmd = [
+                "ffmpeg",
+                "-ss", "0.5",
+                "-i", str(tmp_burned_video.resolve()),
+                "-frames:v", "1",
+                "-update", "1",
+                "-y", str(output.resolve()),
+            ]
+            frame_result = subprocess.run(
+                frame_cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            if frame_result.returncode != 0:
+                stderr_tail = (frame_result.stderr or "")[-500:]
+                logger.error(f"ffmpeg preview frame extraction error: {stderr_tail}")
+            return frame_result.returncode == 0
         finally:
             tmp_ass.unlink(missing_ok=True)
+            tmp_bg_video.unlink(missing_ok=True)
+            tmp_burned_video.unlink(missing_ok=True)
 
     def _burn_ass(self, mp4: Path, ass: Path, output: Path) -> bool:
         """Run ffmpeg to burn the ASS subtitle file into the video."""

--- a/tests/test_funasr_json_to_srt.py
+++ b/tests/test_funasr_json_to_srt.py
@@ -1,0 +1,74 @@
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "third_party"
+    / "funasr-paraformer"
+    / "tools"
+    / "funasr_json_to_srt.py"
+)
+
+
+@pytest.fixture(scope="module")
+def converter_module():
+    spec = importlib.util.spec_from_file_location("funasr_json_to_srt", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_short_segment_preserves_all_wrapped_text(converter_module):
+    cues = converter_module.split_segment_to_cues(
+        text="aa bb cc dd ee ff",
+        start_ms=0,
+        end_ms=600,
+        max_line_length=2,
+        lines_per_cue=1,
+    )
+
+    assert [cue_text for _, _, cue_text in cues] == ["aa", "bb", "cc", "dd", "ee", "ff"]
+    assert all(cue_end > cue_start for cue_start, cue_end, _ in cues)
+    assert cues[-1][1] == 600
+
+
+def test_too_short_segment_regroups_text_without_dropping_lines(converter_module):
+    cues = converter_module.split_segment_to_cues(
+        text="aa bb cc dd ee ff",
+        start_ms=0,
+        end_ms=3,
+        max_line_length=2,
+        lines_per_cue=1,
+    )
+
+    assert len(cues) == 3
+    assert all(cue_end > cue_start for cue_start, cue_end, _ in cues)
+    assert [line for _, _, cue_text in cues for line in cue_text.splitlines()] == [
+        "aa",
+        "bb",
+        "cc",
+        "dd",
+        "ee",
+        "ff",
+    ]
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_positive_int_rejects_non_positive_values(converter_module, value):
+    with pytest.raises(argparse.ArgumentTypeError, match="positive integer"):
+        converter_module.positive_int(value)
+
+
+def test_wrap_text_rejects_non_positive_max_line_length(converter_module):
+    with pytest.raises(ValueError, match="max_line_length"):
+        converter_module.wrap_text("text", 0)
+
+
+def test_split_rejects_non_positive_lines_per_cue(converter_module):
+    with pytest.raises(ValueError, match="lines_per_cue"):
+        converter_module.split_segment_to_cues("text", 0, 1000, 20, 0)

--- a/tests/test_subtitle_burner.py
+++ b/tests/test_subtitle_burner.py
@@ -1,4 +1,9 @@
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
+from PIL import Image, ImageChops
 
 from core.subtitle_burner import SubtitleBurner
 
@@ -118,3 +123,85 @@ def test_build_ass_filter_value_escapes_filter_special_chars(monkeypatch, tmp_pa
     filter_value = SubtitleBurner.build_ass_filter_value(tmp_path / "clip.ass", language="en")
 
     assert "fontsdir=C\\:/Windows/Fonts" in filter_value
+
+
+def test_font_family_from_path_uses_primary_family_name(monkeypatch):
+    class CompletedProcess:
+        returncode = 0
+        stdout = "Heiti TC,黑體-繁,黒体-繁\n"
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: CompletedProcess(),
+    )
+
+    family = SubtitleBurner._font_family_from_path("/System/Library/Fonts/STHeiti Light.ttc")
+
+    assert family == "Heiti TC"
+
+
+def test_generate_preview_image_renders_subtitles(tmp_path):
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        pytest.skip("ffmpeg is not installed")
+
+    filters = subprocess.run(
+        [ffmpeg, "-hide_banner", "-filters"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if " ass " not in filters.stdout:
+        pytest.skip("ffmpeg was built without libass support")
+
+    burner = SubtitleBurner()
+    background_path = tmp_path / "background.png"
+    baseline_video_path = tmp_path / "baseline.mp4"
+    baseline_path = tmp_path / "baseline.png"
+    preview_path = tmp_path / "preview.png"
+
+    burner._create_preview_background(background_path)
+    subprocess.run(
+        [
+            ffmpeg,
+            "-loop", "1",
+            "-i", str(background_path),
+            "-t", "2",
+            "-pix_fmt", "yuv420p",
+            "-an",
+            "-y", str(baseline_video_path),
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    subprocess.run(
+        [
+            ffmpeg,
+            "-ss", "0.5",
+            "-i", str(baseline_video_path),
+            "-frames:v", "1",
+            "-update", "1",
+            "-y", str(baseline_path),
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    ok = burner.generate_preview_image(
+        preview_path,
+        original_text="Preview subtitle",
+    )
+
+    assert ok is True
+    assert baseline_path.exists()
+    assert preview_path.exists()
+    diff = ImageChops.difference(Image.open(baseline_path), Image.open(preview_path))
+    assert diff.getbbox() is not None

--- a/third_party/funasr-paraformer/tools/funasr_json_to_srt.py
+++ b/third_party/funasr-paraformer/tools/funasr_json_to_srt.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert FunASR JSON output into an SRT subtitle file."
+    )
+    parser.add_argument("input_json", help="Path to the FunASR JSON output.")
+    parser.add_argument("output_srt", help="Path to the output SRT file.")
+    parser.add_argument(
+        "--max-line-length",
+        type=int,
+        default=20,
+        help="Soft limit used when wrapping subtitle lines.",
+    )
+    parser.add_argument(
+        "--lines-per-cue",
+        type=int,
+        default=2,
+        help="Maximum number of lines per subtitle cue.",
+    )
+    return parser.parse_args()
+
+
+def srt_timestamp(total_ms: int) -> str:
+    total_ms = max(0, int(total_ms))
+    hours, rem = divmod(total_ms, 3_600_000)
+    minutes, rem = divmod(rem, 60_000)
+    seconds, millis = divmod(rem, 1000)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d},{millis:03d}"
+
+
+def wrap_text(text: str, max_line_length: int) -> list[str]:
+    text = " ".join(text.split())
+    if not text:
+        return []
+
+    lines: list[str] = []
+    break_chars = set(" ，。！？；：,.!?;:、")
+    remaining = text
+
+    while remaining:
+        if len(remaining) <= max_line_length:
+            lines.append(remaining.strip())
+            break
+
+        split_at = max_line_length
+        for idx in range(max_line_length, 0, -1):
+            if remaining[idx - 1] in break_chars:
+                split_at = idx
+                break
+
+        line = remaining[:split_at].strip()
+        if not line:
+            line = remaining[:max_line_length].strip()
+            split_at = max_line_length
+
+        lines.append(line)
+        remaining = remaining[split_at:].lstrip()
+
+    lines = [line for line in lines if line]
+    leading_punc = set("，。！？；：,.!?;:、")
+    for idx in range(1, len(lines)):
+        while lines[idx] and lines[idx][0] in leading_punc:
+            lines[idx - 1] += lines[idx][0]
+            lines[idx] = lines[idx][1:].lstrip()
+    return [line for line in lines if line]
+
+
+def split_segment_to_cues(
+    text: str,
+    start_ms: int,
+    end_ms: int,
+    max_line_length: int,
+    lines_per_cue: int,
+) -> list[tuple[int, int, str]]:
+    lines = wrap_text(text, max_line_length)
+    if not lines:
+        return []
+
+    blocks = [
+        lines[idx : idx + lines_per_cue]
+        for idx in range(0, len(lines), lines_per_cue)
+    ]
+    block_texts = ["\n".join(block) for block in blocks]
+    if len(block_texts) == 1:
+        return [(start_ms, end_ms, block_texts[0])]
+
+    total_duration = max(end_ms - start_ms, len(block_texts) * 500)
+    weights = [max(len(block.replace("\n", "")), 1) for block in block_texts]
+    total_weight = sum(weights)
+
+    cues: list[tuple[int, int, str]] = []
+    cursor = start_ms
+    for idx, (block_text, weight) in enumerate(zip(block_texts, weights), start=1):
+        if idx == len(block_texts):
+            block_end = end_ms
+        else:
+            block_duration = max(int(total_duration * weight / total_weight), 500)
+            block_end = min(end_ms, cursor + block_duration)
+        cues.append((cursor, block_end, block_text))
+        cursor = block_end
+    return cues
+
+
+def main() -> None:
+    args = parse_args()
+    input_json = Path(args.input_json)
+    output_srt = Path(args.output_srt)
+
+    payload = json.loads(input_json.read_text(encoding="utf-8"))
+    segments = payload.get("segments", [])
+
+    output_srt.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_srt.open("w", encoding="utf-8") as fh:
+        index = 1
+        for segment in segments:
+            text = str(segment.get("text", "")).strip()
+            start_ms = int(segment.get("start_ms", 0))
+            end_ms = int(segment.get("end_ms", 0))
+            if not text or end_ms <= start_ms:
+                continue
+
+            cues = split_segment_to_cues(
+                text=text,
+                start_ms=start_ms,
+                end_ms=end_ms,
+                max_line_length=args.max_line_length,
+                lines_per_cue=args.lines_per_cue,
+            )
+            for cue_start, cue_end, cue_text in cues:
+                if cue_end <= cue_start:
+                    continue
+                fh.write(f"{index}\n")
+                fh.write(f"{srt_timestamp(cue_start)} --> {srt_timestamp(cue_end)}\n")
+                fh.write(f"{cue_text}\n\n")
+                index += 1
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/funasr-paraformer/tools/funasr_json_to_srt.py
+++ b/third_party/funasr-paraformer/tools/funasr_json_to_srt.py
@@ -7,6 +7,16 @@ import json
 from pathlib import Path
 
 
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Convert FunASR JSON output into an SRT subtitle file."
@@ -15,13 +25,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("output_srt", help="Path to the output SRT file.")
     parser.add_argument(
         "--max-line-length",
-        type=int,
+        type=positive_int,
         default=20,
         help="Soft limit used when wrapping subtitle lines.",
     )
     parser.add_argument(
         "--lines-per-cue",
-        type=int,
+        type=positive_int,
         default=2,
         help="Maximum number of lines per subtitle cue.",
     )
@@ -37,6 +47,9 @@ def srt_timestamp(total_ms: int) -> str:
 
 
 def wrap_text(text: str, max_line_length: int) -> list[str]:
+    if max_line_length <= 0:
+        raise ValueError("max_line_length must be a positive integer")
+
     text = " ".join(text.split())
     if not text:
         return []
@@ -73,6 +86,55 @@ def wrap_text(text: str, max_line_length: int) -> list[str]:
     return [line for line in lines if line]
 
 
+def group_lines_by_limit(lines: list[str], lines_per_cue: int) -> list[list[str]]:
+    return [
+        lines[idx : idx + lines_per_cue]
+        for idx in range(0, len(lines), lines_per_cue)
+    ]
+
+
+def group_lines_evenly(lines: list[str], cue_count: int) -> list[list[str]]:
+    blocks: list[list[str]] = []
+    cursor = 0
+    for idx in range(cue_count):
+        remaining_lines = len(lines) - cursor
+        remaining_cues = cue_count - idx
+        block_size = (remaining_lines + remaining_cues - 1) // remaining_cues
+        blocks.append(lines[cursor : cursor + block_size])
+        cursor += block_size
+    return blocks
+
+
+def allocate_cue_durations(total_duration: int, weights: list[int]) -> list[int]:
+    cue_count = len(weights)
+    if cue_count == 0:
+        return []
+    if total_duration < cue_count:
+        raise ValueError("total_duration must allow at least 1 ms per cue")
+
+    durations = [1] * cue_count
+    remaining_duration = total_duration - cue_count
+    if remaining_duration == 0:
+        return durations
+
+    total_weight = sum(weights)
+    extra_used = 0
+    remainders: list[tuple[int, int]] = []
+    for idx, weight in enumerate(weights):
+        weighted_duration = remaining_duration * weight
+        extra = weighted_duration // total_weight
+        durations[idx] += extra
+        extra_used += extra
+        remainders.append((weighted_duration % total_weight, idx))
+
+    for _, idx in sorted(remainders, key=lambda item: (-item[0], item[1]))[
+        : remaining_duration - extra_used
+    ]:
+        durations[idx] += 1
+
+    return durations
+
+
 def split_segment_to_cues(
     text: str,
     start_ms: int,
@@ -80,30 +142,36 @@ def split_segment_to_cues(
     max_line_length: int,
     lines_per_cue: int,
 ) -> list[tuple[int, int, str]]:
+    if lines_per_cue <= 0:
+        raise ValueError("lines_per_cue must be a positive integer")
+    if end_ms <= start_ms:
+        return []
+
     lines = wrap_text(text, max_line_length)
     if not lines:
         return []
 
-    blocks = [
-        lines[idx : idx + lines_per_cue]
-        for idx in range(0, len(lines), lines_per_cue)
-    ]
+    blocks = group_lines_by_limit(lines, lines_per_cue)
+    total_duration = end_ms - start_ms
+    if len(blocks) > total_duration:
+        blocks = group_lines_evenly(lines, total_duration)
+
     block_texts = ["\n".join(block) for block in blocks]
     if len(block_texts) == 1:
         return [(start_ms, end_ms, block_texts[0])]
 
-    total_duration = max(end_ms - start_ms, len(block_texts) * 500)
     weights = [max(len(block.replace("\n", "")), 1) for block in block_texts]
-    total_weight = sum(weights)
+    durations = allocate_cue_durations(total_duration, weights)
 
     cues: list[tuple[int, int, str]] = []
     cursor = start_ms
-    for idx, (block_text, weight) in enumerate(zip(block_texts, weights), start=1):
+    for idx, (block_text, duration) in enumerate(
+        zip(block_texts, durations), start=1
+    ):
         if idx == len(block_texts):
             block_end = end_ms
         else:
-            block_duration = max(int(total_duration * weight / total_weight), 500)
-            block_end = min(end_ms, cursor + block_duration)
+            block_end = cursor + duration
         cues.append((cursor, block_end, block_text))
         cursor = block_end
     return cues

--- a/third_party/funasr-paraformer/tools/transcribe_long_audio.py
+++ b/third_party/funasr-paraformer/tools/transcribe_long_audio.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import copy
+import errno
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+import torch
+from funasr import AutoModel
+from modelscope import snapshot_download
+
+# modelscope references errno.EREMOTEIO on Linux, but that symbol does not
+# exist on macOS. Alias it to the closest available constant so downloads can
+# proceed on Darwin instead of crashing during lock handling.
+if not hasattr(errno, "EREMOTEIO"):
+    errno.EREMOTEIO = getattr(errno, "EREMOTE", 121)
+
+DEFAULT_MODEL_IDS = {
+    "zh": {
+        "asr": "iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+        "vad": "iic/speech_fsmn_vad_zh-cn-16k-common-pytorch",
+        "punc": "iic/punc_ct-transformer_cn-en-common-vocab471067-large",
+    },
+    "en": {
+        "asr": "iic/speech_paraformer-large-vad-punc_asr_nat-en-16k-common-vocab10020",
+        "vad": "iic/speech_fsmn_vad_zh-cn-16k-common-pytorch",
+        "punc": "iic/punc_ct-transformer_cn-en-common-vocab471067-large",
+    },
+}
+
+AUDIO_SUFFIXES = {
+    ".wav",
+    ".mp3",
+    ".m4a",
+    ".aac",
+    ".flac",
+    ".ogg",
+    ".opus",
+    ".webm",
+    ".mp4",
+    ".mov",
+    ".mkv",
+}
+
+HAN_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")
+LATIN_RE = re.compile(r"[A-Za-z]")
+
+
+def parse_args() -> argparse.Namespace:
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(
+        description="Run long-form transcription with FunASR Paraformer + VAD + punctuation."
+    )
+    parser.add_argument("input", help="An audio file or a directory containing audio files.")
+    parser.add_argument(
+        "--lang",
+        default="auto",
+        choices=["auto", "zh", "en"],
+        help="Transcription language. auto probes the file first, then switches to the zh or en model.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default=str(root / "outputs"),
+        help="Directory used to store transcription outputs.",
+    )
+    parser.add_argument(
+        "--models-root",
+        default=str(root / "models"),
+        help="Directory that stores the Chinese ASR/VAD/punctuation models.",
+    )
+    parser.add_argument(
+        "--models-root-en",
+        default=str(root / "models_en"),
+        help="Directory that stores the English ASR/VAD/punctuation models.",
+    )
+    parser.add_argument(
+        "--device",
+        default="auto",
+        choices=["auto", "cpu", "cuda", "mps"],
+        help="Inference device. auto picks cuda, then mps, then cpu.",
+    )
+    parser.add_argument(
+        "--ncpu",
+        type=int,
+        default=max(1, min(os.cpu_count() or 4, 8)),
+        help="CPU thread count used by FunASR when running on CPU.",
+    )
+    parser.add_argument(
+        "--batch-size-s",
+        type=int,
+        default=300,
+        help="Maximum total audio seconds merged into one ASR batch after VAD.",
+    )
+    parser.add_argument(
+        "--batch-size-threshold-s",
+        type=int,
+        default=60,
+        help="Segments longer than this threshold are decoded alone.",
+    )
+    parser.add_argument(
+        "--max-single-segment-ms",
+        type=int,
+        default=30000,
+        help="Maximum duration of one VAD segment in milliseconds.",
+    )
+    parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recursively scan audio files when the input is a directory.",
+    )
+    parser.add_argument(
+        "--no-segment-punc",
+        action="store_true",
+        help="Do not run punctuation restoration on per-segment transcripts.",
+    )
+    parser.add_argument(
+        "--disable-pbar",
+        action="store_true",
+        help="Disable FunASR progress bars.",
+    )
+    parser.add_argument(
+        "--cleanup-normalized",
+        action="store_true",
+        help="Delete cached 16k mono wav files after the run finishes.",
+    )
+    parser.add_argument(
+        "--lang-probe-segments",
+        type=int,
+        default=3,
+        help="Number of VAD segments used when --lang auto probes the file language.",
+    )
+    return parser.parse_args()
+
+
+def select_device(requested: str) -> str:
+    if requested == "mps":
+        print(
+            "[device] MPS is incompatible with the current FunASR Paraformer pipeline; falling back to cpu.",
+            file=sys.stderr,
+        )
+        return "cpu"
+    if requested != "auto":
+        return requested
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        print(
+            "[device] Auto-selected MPS is incompatible with the current FunASR Paraformer pipeline; using cpu instead.",
+            file=sys.stderr,
+        )
+        return "cpu"
+    return "cpu"
+
+
+def is_model_ready(target_dir: Path) -> bool:
+    return (target_dir / "configuration.json").exists() or (target_dir / "config.yaml").exists()
+
+
+def ensure_models(models_root: Path, language: str) -> dict[str, Path]:
+    models_root.mkdir(parents=True, exist_ok=True)
+    resolved = {}
+    model_ids = DEFAULT_MODEL_IDS[language]
+    for name, model_id in model_ids.items():
+        target_dir = models_root / name
+        if not is_model_ready(target_dir):
+            print(f"[download:{language}] {name}: {model_id}", file=sys.stderr)
+            snapshot_download(model_id, local_dir=str(target_dir))
+        resolved[name] = target_dir.resolve()
+    return resolved
+
+
+def build_pipeline(
+    model_paths: dict[str, Path],
+    device: str,
+    ncpu: int,
+    max_single_segment_ms: int,
+    disable_pbar: bool,
+) -> AutoModel:
+    return AutoModel(
+        model=str(model_paths["asr"]),
+        vad_model=str(model_paths["vad"]),
+        punc_model=str(model_paths["punc"]),
+        device=device,
+        ncpu=ncpu,
+        disable_update=True,
+        disable_pbar=disable_pbar,
+        hub="ms",
+        vad_kwargs={"max_single_segment_time": max_single_segment_ms},
+    )
+
+
+def collect_audio_files(input_path: Path, recursive: bool) -> list[Path]:
+    if input_path.is_file():
+        return [input_path.resolve()]
+    if not input_path.is_dir():
+        raise FileNotFoundError(f"Input does not exist: {input_path}")
+
+    iterator = input_path.rglob("*") if recursive else input_path.glob("*")
+    files = sorted(
+        path.resolve()
+        for path in iterator
+        if path.is_file() and path.suffix.lower() in AUDIO_SUFFIXES
+    )
+    if not files:
+        raise FileNotFoundError(f"No audio files found under: {input_path}")
+    return files
+
+
+def cache_key(path: Path) -> str:
+    stat = path.stat()
+    payload = f"{path.resolve()}::{stat.st_size}::{stat.st_mtime_ns}"
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def normalize_audio(input_path: Path, cache_dir: Path) -> Path:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    output_path = cache_dir / f"{input_path.stem}-{cache_key(input_path)}.wav"
+    if output_path.exists():
+        return output_path
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(input_path),
+        "-vn",
+        "-sn",
+        "-dn",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        str(output_path),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg failed for {input_path}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    return output_path
+
+
+def load_audio_samples(wav_path: Path) -> np.ndarray:
+    samples, sample_rate = sf.read(str(wav_path), dtype="float32", always_2d=False)
+    if sample_rate != 16000:
+        raise ValueError(f"Expected normalized audio at 16000 Hz, got {sample_rate}: {wav_path}")
+    if isinstance(samples, np.ndarray) and samples.ndim > 1:
+        samples = samples.mean(axis=1)
+    return np.asarray(samples, dtype=np.float32)
+
+
+def slice_segments(samples: np.ndarray, vad_segments: list[list[int]]) -> list[np.ndarray]:
+    chunks = []
+    total = len(samples)
+    for start_ms, end_ms in vad_segments:
+        start = max(0, int(start_ms * 16))
+        end = min(total, int(end_ms * 16))
+        if end > start:
+            chunks.append(samples[start:end])
+    return chunks
+
+
+def run_vad(model: AutoModel, audio_path: Path, disable_pbar: bool) -> list[list[int]]:
+    kwargs = copy.deepcopy(model.vad_kwargs)
+    result = model.inference(
+        str(audio_path),
+        model=model.vad_model,
+        kwargs=kwargs,
+        disable_pbar=disable_pbar,
+    )[0]
+    return result.get("value", [])
+
+
+def run_asr_segments(
+    model: AutoModel,
+    segments: list[np.ndarray],
+    disable_pbar: bool,
+) -> list[str]:
+    if not segments:
+        return []
+
+    kwargs = copy.deepcopy(model.kwargs)
+    kwargs["batch_size"] = 1 if kwargs.get("device") == "cpu" else min(8, len(segments))
+    results = model.inference(
+        segments,
+        model=model.model,
+        kwargs=kwargs,
+        disable_pbar=disable_pbar,
+    )
+    return [item.get("text", "").strip() for item in results]
+
+
+def run_punc_segments(
+    model: AutoModel,
+    texts: list[str],
+    disable_pbar: bool,
+) -> list[str]:
+    results = []
+    for text in texts:
+        if not text:
+            results.append("")
+            continue
+        kwargs = copy.deepcopy(model.punc_kwargs)
+        restored = model.inference(
+            text,
+            model=model.punc_model,
+            kwargs=kwargs,
+            disable_pbar=disable_pbar,
+        )[0]
+        results.append(restored.get("text", text).strip())
+    return results
+
+
+def relative_output_base(input_file: Path, input_root: Path, output_dir: Path) -> Path:
+    if input_root.is_file():
+        rel = Path(input_file.stem)
+    else:
+        rel = input_file.relative_to(input_root)
+        rel = rel.with_suffix("")
+    return output_dir / rel
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def count_pattern(pattern: re.Pattern[str], text: str) -> int:
+    return len(pattern.findall(text))
+
+
+def detect_language_from_text(text: str) -> dict[str, Any]:
+    han_chars = count_pattern(HAN_RE, text)
+    latin_chars = count_pattern(LATIN_RE, text)
+    signal_chars = han_chars + latin_chars
+    han_ratio = han_chars / signal_chars if signal_chars else 0.0
+
+    if han_chars >= 6 and (latin_chars == 0 or han_ratio >= 0.2):
+        language = "zh"
+    elif latin_chars >= 12 and han_chars <= 2:
+        language = "en"
+    elif han_chars >= 3 and han_chars > latin_chars:
+        language = "zh"
+    elif latin_chars > 0:
+        language = "en"
+    else:
+        language = "zh"
+
+    return {
+        "detected_language": language,
+        "han_chars": han_chars,
+        "latin_chars": latin_chars,
+        "signal_chars": signal_chars,
+        "han_ratio": round(han_ratio, 4),
+    }
+
+
+def probe_language(
+    model: AutoModel,
+    normalized_audio: Path,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    vad_segments = run_vad(model, normalized_audio, args.disable_pbar)
+    samples = load_audio_samples(normalized_audio)
+    segment_audio = slice_segments(samples, vad_segments)
+    probe_count = max(1, args.lang_probe_segments)
+    probe_audio = segment_audio[:probe_count]
+    probe_texts = run_asr_segments(model, probe_audio, args.disable_pbar)
+    probe_text = " ".join(text for text in probe_texts if text).strip()
+    metrics = detect_language_from_text(probe_text)
+    return {
+        "mode": "auto_probe",
+        "probe_segments_requested": probe_count,
+        "probe_segments_available": len(segment_audio),
+        "probe_segments_used": len(probe_audio),
+        "probe_texts": probe_texts,
+        "probe_text": probe_text,
+        **metrics,
+    }
+
+
+def transcribe_one(
+    model: AutoModel,
+    input_file: Path,
+    normalized_audio: Path,
+    output_base: Path,
+    args: argparse.Namespace,
+    device: str,
+    language: str,
+    language_detection: dict[str, Any],
+) -> dict[str, Any]:
+    main_result = model.generate(
+        input=str(normalized_audio),
+        batch_size_s=args.batch_size_s,
+        batch_size_threshold_s=args.batch_size_threshold_s,
+        return_raw_text=True,
+        disable_pbar=args.disable_pbar,
+    )[0]
+
+    vad_segments = run_vad(model, normalized_audio, args.disable_pbar)
+    samples = load_audio_samples(normalized_audio)
+    segment_audio = slice_segments(samples, vad_segments)
+    raw_segment_texts = run_asr_segments(model, segment_audio, args.disable_pbar)
+    segment_texts = (
+        raw_segment_texts
+        if args.no_segment_punc
+        else run_punc_segments(model, raw_segment_texts, args.disable_pbar)
+    )
+
+    segments = []
+    for index, vad in enumerate(vad_segments):
+        raw_text = raw_segment_texts[index] if index < len(raw_segment_texts) else ""
+        text = segment_texts[index] if index < len(segment_texts) else raw_text
+        start_ms, end_ms = vad
+        segments.append(
+            {
+                "id": index + 1,
+                "start_ms": start_ms,
+                "end_ms": end_ms,
+                "start_s": round(start_ms / 1000.0, 3),
+                "end_s": round(end_ms / 1000.0, 3),
+                "duration_ms": end_ms - start_ms,
+                "raw_text": raw_text,
+                "text": text,
+            }
+        )
+
+    result = {
+        "input_file": str(input_file),
+        "normalized_audio": str(normalized_audio),
+        "created_at_utc": utc_now_iso(),
+        "device": device,
+        "language": language,
+        "language_detection": language_detection,
+        "models": {
+            "asr": str(Path(model.model_path).resolve()),
+            "vad": str(Path(model.vad_kwargs["model_path"]).resolve()),
+            "punc": str(Path(model.punc_kwargs["model_path"]).resolve()),
+        },
+        "text": main_result.get("text", "").strip(),
+        "raw_text": main_result.get("raw_text", "").strip(),
+        "vad_segment_count": len(vad_segments),
+        "segments": segments,
+    }
+
+    output_base.parent.mkdir(parents=True, exist_ok=True)
+    output_base.with_suffix(".txt").write_text(result["text"] + "\n", encoding="utf-8")
+    output_base.with_suffix(".json").write_text(
+        json.dumps(result, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def cleanup_normalized_files(normalized_dir: Path) -> None:
+    if not normalized_dir.exists():
+        return
+    for wav_file in normalized_dir.glob("*.wav"):
+        wav_file.unlink(missing_ok=True)
+
+
+def model_roots_from_args(args: argparse.Namespace) -> dict[str, Path]:
+    return {
+        "zh": Path(args.models_root).resolve(),
+        "en": Path(args.models_root_en).resolve(),
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    input_path = Path(args.input).resolve()
+    output_dir = Path(args.output_dir).resolve()
+    normalized_dir = output_dir / "_normalized_cache"
+    device = select_device(args.device)
+    models_roots = model_roots_from_args(args)
+
+    files = collect_audio_files(input_path, args.recursive)
+    model_cache: dict[str, AutoModel] = {}
+
+    def get_model(language: str) -> AutoModel:
+        if language not in model_cache:
+            model_paths = ensure_models(models_roots[language], language)
+            model_cache[language] = build_pipeline(
+                model_paths=model_paths,
+                device=device,
+                ncpu=args.ncpu,
+                max_single_segment_ms=args.max_single_segment_ms,
+                disable_pbar=args.disable_pbar,
+            )
+        return model_cache[language]
+
+    summary = []
+    for audio_file in files:
+        print(f"[transcribe] {audio_file}", file=sys.stderr)
+        normalized_audio = normalize_audio(audio_file, normalized_dir)
+        output_base = relative_output_base(audio_file, input_path, output_dir)
+        if args.lang == "auto":
+            detection = probe_language(get_model("zh"), normalized_audio, args)
+            selected_language = detection["detected_language"]
+            print(
+                f"[lang] {audio_file.name}: auto -> {selected_language} "
+                f"(han={detection['han_chars']}, latin={detection['latin_chars']})",
+                file=sys.stderr,
+            )
+        else:
+            selected_language = args.lang
+            detection = {
+                "mode": "explicit",
+                "detected_language": selected_language,
+                "probe_segments_requested": 0,
+                "probe_segments_available": 0,
+                "probe_segments_used": 0,
+                "probe_texts": [],
+                "probe_text": "",
+                "han_chars": 0,
+                "latin_chars": 0,
+                "signal_chars": 0,
+                "han_ratio": 0.0,
+            }
+
+        try:
+            result = transcribe_one(
+                model=get_model(selected_language),
+                input_file=audio_file,
+                normalized_audio=normalized_audio,
+                output_base=output_base,
+                args=args,
+                device=device,
+                language=selected_language,
+                language_detection=detection,
+            )
+        except Exception as exc:
+            if args.lang == "auto" and selected_language == "en":
+                fallback_detection = dict(detection)
+                fallback_detection["fallback_from"] = "en"
+                fallback_detection["fallback_reason"] = str(exc)
+                fallback_detection["detected_language"] = "zh"
+                print(
+                    f"[lang] {audio_file.name}: en pipeline failed, fallback to zh",
+                    file=sys.stderr,
+                )
+                result = transcribe_one(
+                    model=get_model("zh"),
+                    input_file=audio_file,
+                    normalized_audio=normalized_audio,
+                    output_base=output_base,
+                    args=args,
+                    device=device,
+                    language="zh",
+                    language_detection=fallback_detection,
+                )
+            else:
+                raise
+
+        summary.append(
+            {
+                "input_file": result["input_file"],
+                "language": result["language"],
+                "text_file": str(output_base.with_suffix(".txt")),
+                "json_file": str(output_base.with_suffix(".json")),
+                "vad_segment_count": result["vad_segment_count"],
+                "text": result["text"],
+            }
+        )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = output_dir / "summary.jsonl"
+    with summary_path.open("w", encoding="utf-8") as fh:
+        for item in summary:
+            fh.write(json.dumps(item, ensure_ascii=False) + "\n")
+
+    if args.cleanup_normalized:
+        cleanup_normalized_files(normalized_dir)
+        normalized_dir.rmdir() if normalized_dir.exists() and not any(normalized_dir.iterdir()) else None
+
+    print(f"summary: {summary_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fix subtitle rendering reliability across the Streamlit preview and the actual burn path.

Why:
- Chinese subtitle rendering could fail on macOS because fc-scan returns a comma-separated font family list, which broke ASS style parsing when written verbatim.
- The preview path could report success while producing a blank image because ffmpeg did not reliably render ASS subtitles directly onto a single still frame.
- The Paraformer integration also needs local helper scripts for long-audio transcription and JSON-to-SRT conversion when preparing transcripts outside the main app flow.

What changed:
- keep only the primary font family name from fc-scan before writing ASS styles, so CJK subtitle burns render correctly.
- render subtitle previews by creating a short background video, burning the ASS track onto it, and then extracting a frame.
- add regression coverage for primary-family parsing and for preview images actually containing subtitle overlays.
- add vendored FunASR helper tools for long-form transcription and SRT generation under third_party/funasr-paraformer/tools/.