### PR TITLE
feat: add Atlas Cloud LLM provider

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -48,6 +48,7 @@ def _env_float(name: str, default: float) -> float:
 SUPPORTED_LLM_PROVIDERS = (
     "qwen",
     "openrouter",
+    "atlascloud",
     "glm",
     "minimax",
     "custom_openai",
@@ -76,6 +77,16 @@ LLM_CONFIG: Dict[str, Dict[str, Any]] = {
         "default_model": _env_llm_model("openrouter", "stepfun/step-3.5-flash:free"),
         "default_params": {
             "max_tokens": 32768,
+            "temperature": 0.7,
+            "top_p": 0.8,
+            "stream": False
+        }
+    },
+    "atlascloud": {
+        "base_url": _env_llm_base_url("atlascloud", "https://api.atlascloud.ai/v1/chat/completions"),
+        "default_model": _env_llm_model("atlascloud", "deepseek-ai/deepseek-v4-pro"),
+        "default_params": {
+            "max_tokens": 8192,
             "temperature": 0.7,
             "top_p": 0.8,
             "stream": False
@@ -118,6 +129,7 @@ LLM_CONFIG: Dict[str, Dict[str, Any]] = {
 API_KEY_ENV_VARS: Dict[str, str] = {
     "qwen": "QWEN_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "atlascloud": "ATLASCLOUD_API_KEY",
     "glm": "GLM_API_KEY",
     "minimax": "MINIMAX_API_KEY",
     "custom_openai": "CUSTOM_OPENAI_API_KEY",

--- a/core/engaging_moments_analyzer.py
+++ b/core/engaging_moments_analyzer.py
@@ -43,7 +43,7 @@ class EngagingMomentsAnalyzer:
 
         Args:
             api_key: API key for the selected provider (optional, can use env var)
-            provider: LLM provider to use ("qwen", "openrouter", "glm", "minimax", or "custom_openai")
+            provider: LLM provider to use
             use_background: Whether to include background information in prompts
             language: Language for output ("zh" for Chinese, "en" for English)
             debug: Enable debug mode to export full prompts sent to LLM
@@ -77,6 +77,9 @@ class EngagingMomentsAnalyzer:
         elif self.provider == "openrouter":
             from core.llm.openrouter_api_client import OpenRouterAPIClient
             self.llm_client = OpenRouterAPIClient(api_key, base_url=self.base_url)
+        elif self.provider == "atlascloud":
+            from core.llm.atlascloud_api_client import AtlasCloudAPIClient
+            self.llm_client = AtlasCloudAPIClient(api_key, base_url=self.base_url)
         elif self.provider == "glm":
             from core.llm.glm_api_client import GLMAPIClient
             self.llm_client = GLMAPIClient(api_key, base_url=self.base_url)
@@ -87,7 +90,7 @@ class EngagingMomentsAnalyzer:
             from core.llm.custom_openai_api_client import CustomOpenAIAPIClient
             self.llm_client = CustomOpenAIAPIClient(api_key, base_url=self.base_url)
         else:
-            raise ValueError(f"Unsupported provider: {provider}. Supported providers are 'qwen', 'openrouter', 'glm', 'minimax', and 'custom_openai'.")
+            raise ValueError(f"Unsupported provider: {provider}. Supported providers: {', '.join(LLM_CONFIG)}.")
         
         # Load background information if enabled
         if self.use_background:

--- a/core/insights_analyzer.py
+++ b/core/insights_analyzer.py
@@ -53,6 +53,9 @@ class InsightsAnalyzer:
         elif self.provider == "openrouter":
             from core.llm.openrouter_api_client import OpenRouterAPIClient
             self.llm_client = OpenRouterAPIClient(api_key, base_url=self.base_url)
+        elif self.provider == "atlascloud":
+            from core.llm.atlascloud_api_client import AtlasCloudAPIClient
+            self.llm_client = AtlasCloudAPIClient(api_key, base_url=self.base_url)
         elif self.provider == "glm":
             from core.llm.glm_api_client import GLMAPIClient
             self.llm_client = GLMAPIClient(api_key, base_url=self.base_url)
@@ -64,7 +67,7 @@ class InsightsAnalyzer:
             self.llm_client = CustomOpenAIAPIClient(api_key, base_url=self.base_url)
         else:
             raise ValueError(
-                f"Unsupported provider: {provider}. Supported: 'qwen', 'openrouter', 'glm', 'minimax', 'custom_openai'."
+                f"Unsupported provider: {provider}. Supported: {', '.join(LLM_CONFIG)}."
             )
 
         if self.use_background:

--- a/core/llm/atlascloud_api_client.py
+++ b/core/llm/atlascloud_api_client.py
@@ -1,0 +1,17 @@
+"""Atlas Cloud OpenAI-compatible API client."""
+
+import os
+
+from core.config import API_KEY_ENV_VARS, LLM_CONFIG
+from core.llm.custom_openai_api_client import CustomOpenAIAPIClient
+
+
+class AtlasCloudAPIClient(CustomOpenAIAPIClient):
+    """Use Atlas Cloud defaults with the shared OpenAI-compatible client."""
+
+    def __init__(self, api_key: str | None = None, base_url: str | None = None):
+        super().__init__(
+            api_key=api_key or os.getenv(API_KEY_ENV_VARS["atlascloud"]),
+            base_url=base_url or LLM_CONFIG["atlascloud"]["base_url"],
+        )
+        self.default_model = LLM_CONFIG["atlascloud"]["default_model"]

--- a/core/subtitle_burner.py
+++ b/core/subtitle_burner.py
@@ -212,6 +212,9 @@ class SubtitleBurner:
             if provider == "openrouter":
                 from core.llm.openrouter_api_client import OpenRouterAPIClient
                 self.client = OpenRouterAPIClient(api_key=api_key, base_url=base_url)
+            elif provider == "atlascloud":
+                from core.llm.atlascloud_api_client import AtlasCloudAPIClient
+                self.client = AtlasCloudAPIClient(api_key=api_key, base_url=base_url)
             elif provider == "glm":
                 from core.llm.glm_api_client import GLMAPIClient
                 self.client = GLMAPIClient(api_key=api_key, base_url=base_url)

--- a/tests/test_atlascloud_client.py
+++ b/tests/test_atlascloud_client.py
@@ -1,0 +1,24 @@
+from core.engaging_moments_analyzer import EngagingMomentsAnalyzer
+from core.insights_analyzer import InsightsAnalyzer
+from core.llm.atlascloud_api_client import AtlasCloudAPIClient
+from core.subtitle_burner import SubtitleBurner
+
+
+def test_atlascloud_client_uses_provider_defaults(monkeypatch):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-key")
+
+    client = AtlasCloudAPIClient()
+
+    assert client.api_key == "atlas-key"
+    assert client.base_url == "https://api.atlascloud.ai/v1/chat/completions"
+    assert client.default_model == "deepseek-ai/deepseek-v4-pro"
+
+
+def test_atlascloud_provider_is_used_by_analysis_and_subtitles():
+    analyzer = EngagingMomentsAnalyzer(provider="atlascloud", api_key="atlas-key")
+    insights = InsightsAnalyzer(provider="atlascloud", api_key="atlas-key")
+    burner = SubtitleBurner(provider="atlascloud", api_key="atlas-key", enable_llm=True)
+
+    assert isinstance(analyzer.llm_client, AtlasCloudAPIClient)
+    assert isinstance(insights.llm_client, AtlasCloudAPIClient)
+    assert isinstance(burner.client, AtlasCloudAPIClient)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,7 @@ def test_llm_config_uses_environment_overrides(monkeypatch):
         env.setenv("QWEN_BASE_URL", "https://qwen.example/v1")
         env.setenv("QWEN_MODEL", "qwen-test")
         env.setenv("OPENROUTER_BASE_URL", "https://router.example/api/v1/")
+        env.setenv("ATLASCLOUD_MODEL", "atlas-test")
         env.setenv("GLM_BASE_URL", "https://glm.example/api/paas/v4")
         env.setenv("MINIMAX_MODEL", "MiniMax-Test")
         env.setenv("CUSTOM_OPENAI_BASE_URL", "https://openai.example/v1/")
@@ -30,6 +31,8 @@ def test_llm_config_uses_environment_overrides(monkeypatch):
         assert reloaded.LLM_CONFIG["qwen"]["base_url"] == "https://qwen.example/v1/chat/completions"
         assert reloaded.LLM_CONFIG["qwen"]["default_model"] == "qwen-test"
         assert reloaded.LLM_CONFIG["openrouter"]["base_url"] == "https://router.example/api/v1/chat/completions"
+        assert reloaded.LLM_CONFIG["atlascloud"]["base_url"] == "https://api.atlascloud.ai/v1/chat/completions"
+        assert reloaded.LLM_CONFIG["atlascloud"]["default_model"] == "atlas-test"
         assert reloaded.LLM_CONFIG["glm"]["base_url"] == "https://glm.example/api/paas/v4/chat/completions"
         assert reloaded.LLM_CONFIG["minimax"]["default_model"] == "MiniMax-Test"
         assert reloaded.LLM_CONFIG["custom_openai"]["base_url"] == "https://openai.example/v1/chat/completions"


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a first-class LLM provider in the Streamlit provider selector
- reuse the existing OpenAI-compatible client with Atlas Cloud endpoint, key, and model defaults
- route highlight analysis, insight extraction, and subtitle translation through the provider
- cover configuration, client defaults, and runtime selection with focused tests

## Testing

- `.venv/bin/python -m pytest -q tests/test_config.py tests/test_atlascloud_client.py tests/test_custom_openai_client.py` (10 passed)
- `.venv/bin/python -m pytest -q -m 'not slow and not network and not integration and not e2e'` (156 passed, 1 skipped, 1 unrelated failure because local `ffmpeg`/`ffprobe` are unavailable)
- `uvx ruff check core/llm/atlascloud_api_client.py tests/test_atlascloud_client.py`
- `.venv/bin/python -m compileall -q core tests/test_atlascloud_client.py tests/test_config.py`
- live chat request through `AtlasCloudAPIClient` (non-empty response)
- `git diff --check`
